### PR TITLE
Sql statement/insert

### DIFF
--- a/src/js/createSql.js
+++ b/src/js/createSql.js
@@ -1,3 +1,4 @@
+var squel = require('squel');
 var createStatement = require('./createStatement.js').createStatement;
 var _ = require('lodash');
 /**
@@ -92,8 +93,13 @@ module.exports = {
    *
    * @return {string}
    */
-  insert: function() {
-    return 'insert dummy.';
+  insert: function(data) {
+    var table = data.table;
+    var value = data.data;
+    var res;
+
+    res = squel.insert().into(table).setFieldsRows(value);
+    return res.toString();
   },
   /**
    * delete文を生成

--- a/test/js/createSqlTest.js
+++ b/test/js/createSqlTest.js
@@ -113,4 +113,40 @@ describe('createSqlで', function() {
       assert.equal(actual, 'CREATE TABLE Aテーブル (a_id int(4)) FOREIGN KEY (b) REFERENCES bテーブル(b)');
     });
   });
+
+  describe('INSERT文を生成', function() {
+    var insertTable;
+    beforeEach(function(done) {
+      insertTable = {
+        'table': 'Aテーブル',
+        'data': [{
+          'id': 1,
+          'name': 'aaa'
+        }]
+      };
+      done();
+    });
+    it('INSERT文が表示できているか', function() {
+      var actual = createSql.insert(insertTable);
+      var except = 'INSERT INTO Aテーブル (id, name) VALUES (1, \'aaa\')';
+      assert.equal(actual, except);
+    });
+
+    it('複数の値があるINSERT文が表示できているか', function() {
+      var except;
+      var actual;
+      insertTable.data = [
+        {
+          'id': 1,
+          'name': 'aaa'
+        },
+        {
+          'id': 2,
+          'name': 'bbb'
+        }];
+      actual = createSql.insert(insertTable);
+      except = 'INSERT INTO Aテーブル (id, name) VALUES (1, \'aaa\'), (2, \'bbb\')';
+      assert.equal(actual, except);
+    });
+  });
 });

--- a/test/js/createSqlTest.js
+++ b/test/js/createSqlTest.js
@@ -4,98 +4,97 @@ var assert = require('power-assert');
 var createSql = require('../../src/js/createSql.js');
 
 describe('createSqlで', function() {
-  var table;
-  var table2;
-  var table3;
-  var table4;
-  table = {
-    'table': 'Aテーブル',
-    'columns': [
-      {
-        'name': 'a_id',
-        'dataType': 'int',
-        'leng': '4',
-        'const': []
-      },
-      {
-        'name': 'b',
-        'dataType': 'string',
-        'leng': '16',
-        'const': [
-          'NOT NULL'
-        ]
-      },
-      {
-        'name': 'c',
-        'dataType': 'string',
-        'leng': '',
-        'const': []
-      }
-    ],
-    'constraint': {
-      'primary_key': [
-        'a_id',
-        'b'
-      ],
-      'foreign_key': [
-        {
-          'col_name': 'b',
-          'table': 'bテーブル',
-          'parent_col': 'b'
-        }
-      ]
-    }
-  };
-  table2 = {
-    'table': 'Aテーブル',
-    'columns': [
-      {
-        'name': 'a_id',
-        'dataType': 'int',
-        'leng': '4',
-        'const': []
-      }
-    ],
-    'constraint': {}
-  };
-  table3 = {
-    'table': 'Aテーブル',
-    'columns': [
-      {
-        'name': 'a_id',
-        'dataType': 'int',
-        'leng': '4',
-        'const': []
-      }
-    ],
-    'constraint': {
-      'primary_key': [
-        'a_id'
-      ]
-    }
-  };
-  table4 = {
-    'table': 'Aテーブル',
-    'columns': [
-      {
-        'name': 'a_id',
-        'dataType': 'int',
-        'leng': '4',
-        'const': []
-      }
-    ],
-    'constraint': {
-      'foreign_key': [
-        {
-          'col_name': 'b',
-          'table': 'bテーブル',
-          'parent_col': 'b'
-        }
-      ]
-    }
-  };
-
   describe('tableからcreate文を生成', function() {
+    var table;
+    var table2;
+    var table3;
+    var table4;
+    table = {
+      'table': 'Aテーブル',
+      'columns': [
+        {
+          'name': 'a_id',
+          'dataType': 'int',
+          'leng': '4',
+          'const': []
+        },
+        {
+          'name': 'b',
+          'dataType': 'string',
+          'leng': '16',
+          'const': [
+            'NOT NULL'
+          ]
+        },
+        {
+          'name': 'c',
+          'dataType': 'string',
+          'leng': '',
+          'const': []
+        }
+      ],
+      'constraint': {
+        'primary_key': [
+          'a_id',
+          'b'
+        ],
+        'foreign_key': [
+          {
+            'col_name': 'b',
+            'table': 'bテーブル',
+            'parent_col': 'b'
+          }
+        ]
+      }
+    };
+    table2 = {
+      'table': 'Aテーブル',
+      'columns': [
+        {
+          'name': 'a_id',
+          'dataType': 'int',
+          'leng': '4',
+          'const': []
+        }
+      ],
+      'constraint': {}
+    };
+    table3 = {
+      'table': 'Aテーブル',
+      'columns': [
+        {
+          'name': 'a_id',
+          'dataType': 'int',
+          'leng': '4',
+          'const': []
+        }
+      ],
+      'constraint': {
+        'primary_key': [
+          'a_id'
+        ]
+      }
+    };
+    table4 = {
+      'table': 'Aテーブル',
+      'columns': [
+        {
+          'name': 'a_id',
+          'dataType': 'int',
+          'leng': '4',
+          'const': []
+        }
+      ],
+      'constraint': {
+        'foreign_key': [
+          {
+            'col_name': 'b',
+            'table': 'bテーブル',
+            'parent_col': 'b'
+          }
+        ]
+      }
+    };
     it('create文のテーブルか表示できているか', function() {
       var actual = createSql.create(table);
       assert.equal(actual, 'CREATE TABLE Aテーブル (a_id int(4), b string(16) NOT NULL, c string) PRIMARY KEY(a_id, b) FOREIGN KEY (b) REFERENCES bテーブル(b)');
@@ -116,7 +115,11 @@ describe('createSqlで', function() {
 
   describe('INSERT文を生成', function() {
     var insertTable;
+    var except;
+    var actual;
     beforeEach(function(done) {
+      except = '';
+      actual = '';
       insertTable = {
         'table': 'Aテーブル',
         'data': [{
@@ -127,14 +130,12 @@ describe('createSqlで', function() {
       done();
     });
     it('INSERT文が表示できているか', function() {
-      var actual = createSql.insert(insertTable);
-      var except = 'INSERT INTO Aテーブル (id, name) VALUES (1, \'aaa\')';
+      actual = createSql.insert(insertTable);
+      except = 'INSERT INTO Aテーブル (id, name) VALUES (1, \'aaa\')';
       assert.equal(actual, except);
     });
 
     it('複数の値があるINSERT文が表示できているか', function() {
-      var except;
-      var actual;
       insertTable.data = [
         {
           'id': 1,


### PR DESCRIPTION
## 技術的変更点
- `createSql.insert()`でINSERT文生成
- 複数行のINSERTにも対応
## 注意事項
- 複数行のINSERTを行う場合、値を配列にしてください。

```
data: [{
             'id': 1,
             'name': 'aaa'
       },
       {
             'id': 2,
             'name': 'bbb'
       }];
```
## チェックリスト
- [ ] 誤字脱字はないか
## その他

なし
